### PR TITLE
The support of Postgresql has completed.

### DIFF
--- a/lib/CHI/Driver/DBI/t/CHIDriverTests/Pg.pm
+++ b/lib/CHI/Driver/DBI/t/CHIDriverTests/Pg.pm
@@ -1,0 +1,17 @@
+package CHI::Driver::DBI::t::CHIDriverTests::Pg;
+use strict; 
+use warnings;
+
+use base qw(CHI::Driver::DBI::t::CHIDriverTests::Base);
+
+sub require_modules { return { 'DBD::Pg' => undef } }
+
+sub dsn {
+    return 'dbi:Pg:dbname=pesystem';
+}
+
+sub cleanup : Tests( shutdown ) {
+}
+
+1;
+__END__

--- a/t/CHIDriverTests-Pg.t
+++ b/t/CHIDriverTests-Pg.t
@@ -1,0 +1,5 @@
+#!perl -w
+use strict;
+use warnings;
+use CHI::Driver::DBI::t::CHIDriverTests::Pg;
+CHI::Driver::DBI::t::CHIDriverTests::Pg->runtests;


### PR DESCRIPTION
beacuse of postgresql will produce a "NOTICE: relation "chi_Default already exists"" when execute create table use the the SQL " create table  if not exists "chi_Default" ( ... )  ". 

**since  a test failure** : non-overridable subcache keys 
    NOTICE:  relation "chi_Default" already exists, skipping

```
#   Failed test 'non-overridable subcache keys'
#   at /usr/local/lib/perl5/site_perl/5.16.2/CHI/t/Driver.pm line 942.
#   (in CHI::Driver::DBI::t::CHIDriverTests::Pg->test_subcache_overridable_params)
# found warning: cannot override these keys in a subcache: expires_variance, serializer   at /usr/local/lib/perl5/site_perl/5.16.2/CHI/Driver/Role/HasSubcaches.pm line 56.
# found warning: NOTICE:  relation "chi_Default" already exists, skipping
# expected to find warning: (?^:cannot override these keys)
```

you can change the test function ,  warnings_like 's regular expression to [qr/cannot override these keys/], to fix this fake failure !

thanks !
