### PR TITLE
Works with DB handles with RaiseError = 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Emacs backup files
+**~
+
 *.tar.gz
 .lwpcookies
 .tidyall.d

--- a/dist.ini
+++ b/dist.ini
@@ -41,6 +41,7 @@ Moose = 0.66
 [Prereqs / TestRequires]
 Test::Class = 0
 Test::More = 0
+Test::PostgreSQL = 1.05
 
 ; These need to be at the bottom
 [InstallGuide]

--- a/lib/CHI/Driver/DBI.pm
+++ b/lib/CHI/Driver/DBI.pm
@@ -108,6 +108,8 @@ sub fetch {
     my $dbh = $self->has_dbh_ro ? $self->dbh_ro->() : $self->dbh->();
     my $sth = $dbh->prepare_cached( $self->sql_strings->{fetch} )
       or croak $dbh->errstr;
+    $sth->{RaiseError} = 0; # This code assumes RaiseError = 0
+
     if ( $self->db_name eq 'PostgreSQL' ) {
         $sth->bind_param( 1, undef, { pg_type => DBD::Pg::PG_BYTEA() } );
     }
@@ -122,6 +124,8 @@ sub store {
 
     my $dbh = $self->dbh->();
     my $sth = $dbh->prepare_cached( $self->sql_strings->{store} );
+    $sth->{RaiseError} = 0; # This code assumes RaiseError = 0
+
     if ( $self->db_name eq 'PostgreSQL' ) {
         $sth->bind_param( 1, undef, { pg_type => DBD::Pg::PG_BYTEA() } );
         $sth->bind_param( 2, undef, { pg_type => DBD::Pg::PG_BYTEA() } );
@@ -131,6 +135,7 @@ sub store {
             my $sth = $dbh->prepare_cached( $self->sql_strings->{store2} )
               or croak $dbh->errstr;
             if ( $self->db_name eq 'PostgreSQL' ) {
+                $sth->{RaiseError} = 0;
                 $sth->bind_param( 1, undef,
                     { pg_type => DBD::Pg::PG_BYTEA() } );
                 $sth->bind_param( 2, undef,
@@ -154,6 +159,8 @@ sub remove {
     my $dbh = $self->dbh->();
     my $sth = $dbh->prepare_cached( $self->sql_strings->{remove} )
       or croak $dbh->errstr;
+    $sth->{RaiseError} = 0; # This code assumes RaiseError = 0
+
     if ( $self->db_name eq 'PostgreSQL' ) {
         $sth->bind_param( 1, undef, { pg_type => DBD::Pg::PG_BYTEA() } );
     }
@@ -169,6 +176,8 @@ sub clear {
     my $dbh = $self->dbh->();
     my $sth = $dbh->prepare_cached( $self->sql_strings->{clear} )
       or croak $dbh->errstr;
+    $sth->{RaiseError} = 0; # This code assumes RaiseError = 0
+
     $sth->execute() or croak $sth->errstr;
     $sth->finish();
 
@@ -181,6 +190,8 @@ sub get_keys {
     my $dbh = $self->has_dbh_ro ? $self->dbh_ro->() : $self->dbh->();
     my $sth = $dbh->prepare_cached( $self->sql_strings->{get_keys} )
       or croak $dbh->errstr;
+    $sth->{RaiseError} = 0; # This code assumes RaiseError = 0
+
     $sth->execute() or croak $sth->errstr;
     my $results = $sth->fetchall_arrayref( [0] );
     $_ = $_->[0] for @{$results};

--- a/lib/CHI/Driver/DBI/t/CHIDriverTests/Base.pm
+++ b/lib/CHI/Driver/DBI/t/CHIDriverTests/Base.pm
@@ -29,6 +29,7 @@ sub dbh {
             {
                 RaiseError => 0,
                 PrintError => 0,
+                PrintWarn => 0,
             }
         );
     };

--- a/lib/CHI/Driver/DBI/t/CHIDriverTests/Pg.pm
+++ b/lib/CHI/Driver/DBI/t/CHIDriverTests/Pg.pm
@@ -2,12 +2,30 @@ package CHI::Driver::DBI::t::CHIDriverTests::Pg;
 use strict;
 use warnings;
 
+use Test::PostgreSQL;
 use base qw(CHI::Driver::DBI::t::CHIDriverTests::Base);
 
-sub require_modules { return { 'DBD::Pg' => undef } }
+sub require_modules { return { 'DBD::Pg' => undef,
+                               'Test::PostgreSQL' => undef,
+                             } }
+
+# Building a test instance of PostgreSQL
+{
+    my $dsn;
+    my $pgsql; # This needs to be there, cause the PostgreSQL test instance goes down on destroy.
+    sub _get_dsn{
+        $dsn ||= do{
+            $pgsql = Test::PostgreSQL->new()
+              or diag($Test::PostgreSQL::errstr);
+            $pgsql ? $pgsql->dsn : 'Cannot build a postgresql DSN';
+        };
+        return $dsn;
+    }
+}
 
 sub dsn {
-    return 'dbi:Pg:dbname=pesystem';
+    my $dsn = _get_dsn();
+    return _get_dsn();
 }
 
 sub cleanup : Tests( shutdown ) {

--- a/lib/CHI/Driver/DBI/t/CHIDriverTests/PgErrors.pm
+++ b/lib/CHI/Driver/DBI/t/CHIDriverTests/PgErrors.pm
@@ -1,0 +1,40 @@
+package CHI::Driver::DBI::t::CHIDriverTests::PgErrors;
+use strict;
+use warnings;
+
+use Test::PostgreSQL;
+use base qw(CHI::Driver::DBI::t::CHIDriverTests::Pg);
+use Test::More;
+
+## Override CHI::Driver::DBI::t::CHIDriverTests::Base
+## to test that things work with RaiseError => 1
+sub dbh {
+    my $self = shift;
+
+    eval {
+        return DBI->connect(
+            $self->dsn(),
+            '', '',
+            {
+                RaiseError => 1,
+                PrintError => 0,
+                PrintWarn => 0,
+            }
+        );
+    };
+}
+
+
+sub test_raiseerror_persists : Tests{
+    my ($self) = @_;
+    my $dbh = $self->dbh();
+    ok( $dbh->{RaiseError} , "Ok DBH has got RaiseError");
+    my $sth = $dbh->prepare_cached('SELECT 1');
+    ok( $sth->{RaiseError} , "New statement has got RaiseError");
+}
+
+sub cleanup : Tests( shutdown ) {
+}
+
+1;
+__END__

--- a/t/CHIDriverTests-PgErrors.t
+++ b/t/CHIDriverTests-PgErrors.t
@@ -1,0 +1,5 @@
+#!perl -w
+use strict;
+use warnings;
+use CHI::Driver::DBI::t::CHIDriverTests::PgErrors;
+CHI::Driver::DBI::t::CHIDriverTests::PgErrors->runtests;


### PR DESCRIPTION
This fixes the case where this package wouldn't work with Postgresql when the connection attribute RaiseError = 1
