### PR TITLE
Start using bind_param in MySQL, MariaDB and SQLite

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,6 +1,7 @@
 #!perl -T
 
 use Test::More tests => 1;
+use DBI;
 
 BEGIN {
     use_ok('CHI::Driver::DBI');


### PR DESCRIPTION
Handling BLOB differs in MySQL and MariaDB driver so starting to use bind_param with execute to make sure that SQL types are correctly recognized